### PR TITLE
ci: add aggregate required-check jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,6 +107,19 @@ jobs:
           name: wheels-musllinux-${{ matrix.python-version }}-${{ matrix.platform.target }}
           path: dist
 
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [macos, linux, musllinux]
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,7 +108,7 @@ jobs:
           path: dist
 
   ci:
-    name: CI
+    name: Builds Pass
     runs-on: ubuntu-latest
     if: always()
     needs: [macos, linux, musllinux]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,3 +48,16 @@ jobs:
           uv sync --frozen --only-dev
 
       - uses: j178/prek-action@v2
+
+  tests:
+    name: Tests Pass
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [pytest, pre-commit]
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds a `ci` job to `CI.yml` (display name **CI**) that runs after all wheel-build matrix jobs (macos, linux, musllinux)
- Adds a `tests` job to `test.yml` (display name **Tests Pass**) that runs after pytest and pre-commit
- Both use `if: always()` so they always run, and fail if any upstream job failed or was cancelled