### PR TITLE
ci: run wheel builds on push to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches: ["main"]
     tags: ["v*"]
   release:
     types: [published]


### PR DESCRIPTION
## Summary

- Adds `branches: ["main"]` to the `push:` trigger in `CI.yml`
- Rust/maturin wheel builds now run on every merge to main, not just PRs and `v*` tags
- "Builds Pass" status check will appear on main branch commits alongside the existing "Tests Pass" check from `test.yml`